### PR TITLE
feat: Make window scroll to top when entering room

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -32,6 +32,13 @@ const routes = [
 const router = new VueRouter({
   mode: "history",
   routes,
+  scrollBehavior(savedPosition) {
+    if (savedPosition) {
+      return savedPosition;
+    } else {
+      return { x: 0, y: 0 };
+    }
+  },
 });
 
 export default router;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -32,7 +32,7 @@ const routes = [
 const router = new VueRouter({
   mode: "history",
   routes,
-  scrollBehavior(savedPosition) {
+  scrollBehavior(from,to,savedPosition) {
     if (savedPosition) {
       return savedPosition;
     } else {


### PR DESCRIPTION
When entering room the window now scrolls to the top. At smaller viewports selecting the last room in the available list caused the room page to load and the browser to maintain its scroll position. This means that the user can not read the introduction to the task, and must manually scroll to the top before starting.